### PR TITLE
Storage Reorder and History

### DIFF
--- a/data/beverages.json
+++ b/data/beverages.json
@@ -81,7 +81,7 @@
         "nr": "1001202",
         "articleid": "407506",
         "articletype": "10012",
-        "name": "Dworek Vodka",
+        "name": "Dworek Vodka ",
         "name2": "",
         "priceinclvat": "100.00",
         "volumeml": null,

--- a/js/controllers/storageController.js
+++ b/js/controllers/storageController.js
@@ -4,54 +4,71 @@ import StorageView from "../views/storageView.js";
 class StorageController {
   constructor(app) {
     this.app = app;
-    this.model = new StorageModel();
+    this.model = new StorageModel(app.database);
     this.view = new StorageView();
+    this.view.onReorder = this.handleReorder.bind(this);
     this.init();
   }
 
   async init() {
-    await this.model.loadStorageData();
+    await this.model.loadStorageAndOrderHistoryData();
     this.ensureStockValues();
-    // this.render();
   }
 
+  // Ensure that all products have a stock value
   ensureStockValues() {
     let stockUpdated = false;
-    this.model.beverages.forEach(beverage => {
+    this.model.beverages.forEach((beverage) => {
       if (beverage.stock === undefined) {
         beverage.stock = 10;
         stockUpdated = true;
       }
     });
-    this.model.foods.forEach(food => {
+    this.model.foods.forEach((food) => {
       if (food.stock === undefined) {
         food.stock = 10;
         stockUpdated = true;
       }
     });
+
+    // Save changes to the database
     if (stockUpdated) {
       this.model.saveStockData();
     }
   }
 
+  handleReorder(itemName) {
+    const product =
+      this.model.beverages.find((b) => b.name === itemName) ||
+      this.model.foods.find((f) => f.name === itemName);
+
+    if (product) {
+      product.stock = 10; // Reset stock to 10
+      this.model.saveStockData(); // Persist changes
+      this.model.addOrder(itemName); // Save order in history
+
+      this.render(); // Re-render UI with updated order log
+    }
+  }
+
   async render() {
     // Always load fresh data from the database
-    await this.model.loadStorageData();
+    await this.model.loadStorageAndOrderHistoryData();
     this.ensureStockValues();
 
     const storageItems = [
-      ...this.model.beverages.map(beverage => ({
+      ...this.model.beverages.map((beverage) => ({
         name: beverage.name,
         stock: beverage.stock,
-        reorderThreshold: 5 // can be changed later
+        reorderThreshold: 5, // can be changed later
       })),
-      ...this.model.foods.map(food => ({
+      ...this.model.foods.map((food) => ({
         name: food.name,
         stock: food.stock,
-        reorderThreshold: 5 // can be changed later
-      }))
+        reorderThreshold: 5, // can be changed later
+      })),
     ];
-    await this.view.render(storageItems);
+    await this.view.render(storageItems, this.model.getOrderHistory());
   }
 }
 

--- a/js/html/storage.html
+++ b/js/html/storage.html
@@ -20,7 +20,7 @@
     <div class="order-history">
       <h3>Recent Orders</h3>
       <ul id="order-log">
-        <li>No orders yet.</li>
+        <!-- <li>No orders yet.</li> -->
       </ul>
     </div>
   </div>

--- a/js/models/database.js
+++ b/js/models/database.js
@@ -2,11 +2,11 @@
 class Database {
   constructor() {
     // Initialize data in localStorage if it doesn't exist
-    if (!localStorage.getItem('users')) {
-      localStorage.setItem('users', JSON.stringify([]));
+    if (!localStorage.getItem("users")) {
+      localStorage.setItem("users", JSON.stringify([]));
     }
-    if (!localStorage.getItem('orders')) {
-      localStorage.setItem('orders', JSON.stringify([]));
+    if (!localStorage.getItem("orders")) {
+      localStorage.setItem("orders", JSON.stringify([]));
     }
   }
 

--- a/js/views/StorageView.js
+++ b/js/views/StorageView.js
@@ -1,36 +1,50 @@
 class StorageView {
   constructor() {
     this.appContent = document.getElementById("app-content");
+    this.onReorder = () => {}; // Callback function
   }
 
-  async render(storageItems) {
-    this.inventory = storageItems;
-
+  // storageItems: Array of objects with name, stock, and reorderThreshold properties
+  // orderHistory: Array of objects with name and time properties
+  async render(storageItems, orderHistory) {
     try {
       const response = await fetch("js/html/storage.html");
       const html = await response.text();
       this.appContent.innerHTML = html;
 
-      // Fill in the table contents
-      this.populateStorageTable();
+      // Fill in the table contents with storage items
+      this.populateStorageTable(storageItems);
 
-      // Call function to enable tab switching
+      // Fill in the order log with order history
+      this.renderOrderLog(orderHistory);
+
+      // Attach event listeners
       this.setupEventListeners();
     } catch (error) {
       console.error("Error loading login.html:", error);
     }
   }
 
-  populateStorageTable() {
+  setupEventListeners() {
+    // Reorder button event listeners
+    document.querySelectorAll(".reorder-btn").forEach((button) => {
+      button.addEventListener("click", (event) => {
+        const itemName = event.target.getAttribute("data-item");
+        // Call the reorderItem method with the item name
+        this.reorderItem(itemName);
+      });
+    });
+  }
+
+  // Fill in the table with storage items
+  populateStorageTable(storageItems) {
     const storageList = document.getElementById("storage-list");
     if (!storageList) return;
 
-    storageList.innerHTML = this.inventory
+    storageList.innerHTML = storageItems
       .map(
         (item) => `
-        <tr class="${
-          item.stock <= item.reorderThreshold ? "low-stock" : ""
-        }">
+        <tr class="${item.stock <= item.reorderThreshold ? "low-stock" : ""}">
             <td>${item.name}</td>
             <td>${item.stock}</td>
             <td>
@@ -44,25 +58,23 @@ class StorageView {
     `
       )
       .join("");
-
-    this.setupEventListeners(); // Re-attach event listeners
   }
 
-  setupEventListeners() {
-    document.querySelectorAll(".reorder-btn").forEach((button) => {
-      button.addEventListener("click", (event) => {
-        const itemName = event.target.getAttribute("data-item");
-        this.reorderItem(itemName);
-      });
-    });
+  // Fill in the order log with order history
+  renderOrderLog(orderHistory) {
+    const orderLog = document.getElementById("order-log");
+    if (!orderLog) return;
+
+    if (orderHistory.length === 0) {
+      orderLog.innerHTML = "<li>No orders placed yet</li>";
+    } else
+      orderLog.innerHTML = orderHistory
+        .map((order) => `<li>✅ Reordered ${order.name} - ${order.time}</li>`)
+        .join("");
   }
 
   reorderItem(itemName) {
-    const orderLog = document.getElementById("order-log");
-    orderLog.innerHTML =
-      `<li>✅ Reordered ${itemName} - ${new Date().toLocaleTimeString()}</li>` +
-      orderLog.innerHTML;
-    alert(`Reordered ${itemName}!`);
+    this.onReorder(itemName);
   }
 }
 

--- a/js/views/storageView.js
+++ b/js/views/storageView.js
@@ -1,36 +1,50 @@
 class StorageView {
   constructor() {
     this.appContent = document.getElementById("app-content");
+    this.onReorder = () => {}; // Callback function
   }
 
-  async render(storageItems) {
-    this.inventory = storageItems;
-
+  // storageItems: Array of objects with name, stock, and reorderThreshold properties
+  // orderHistory: Array of objects with name and time properties
+  async render(storageItems, orderHistory) {
     try {
       const response = await fetch("js/html/storage.html");
       const html = await response.text();
       this.appContent.innerHTML = html;
 
-      // Fill in the table contents
-      this.populateStorageTable();
+      // Fill in the table contents with storage items
+      this.populateStorageTable(storageItems);
 
-      // Call function to enable tab switching
+      // Fill in the order log with order history
+      this.renderOrderLog(orderHistory);
+
+      // Attach event listeners
       this.setupEventListeners();
     } catch (error) {
       console.error("Error loading login.html:", error);
     }
   }
 
-  populateStorageTable() {
+  setupEventListeners() {
+    // Reorder button event listeners
+    document.querySelectorAll(".reorder-btn").forEach((button) => {
+      button.addEventListener("click", (event) => {
+        const itemName = event.target.getAttribute("data-item");
+        // Call the reorderItem method with the item name
+        this.reorderItem(itemName);
+      });
+    });
+  }
+
+  // Fill in the table with storage items
+  populateStorageTable(storageItems) {
     const storageList = document.getElementById("storage-list");
     if (!storageList) return;
 
-    storageList.innerHTML = this.inventory
+    storageList.innerHTML = storageItems
       .map(
         (item) => `
-        <tr class="${
-          item.stock <= item.reorderThreshold ? "low-stock" : ""
-        }">
+        <tr class="${item.stock <= item.reorderThreshold ? "low-stock" : ""}">
             <td>${item.name}</td>
             <td>${item.stock}</td>
             <td>
@@ -44,25 +58,23 @@ class StorageView {
     `
       )
       .join("");
-
-    this.setupEventListeners(); // Re-attach event listeners
   }
 
-  setupEventListeners() {
-    document.querySelectorAll(".reorder-btn").forEach((button) => {
-      button.addEventListener("click", (event) => {
-        const itemName = event.target.getAttribute("data-item");
-        this.reorderItem(itemName);
-      });
-    });
+  // Fill in the order log with order history
+  renderOrderLog(orderHistory) {
+    const orderLog = document.getElementById("order-log");
+    if (!orderLog) return;
+
+    if (orderHistory.length === 0) {
+      orderLog.innerHTML = "<li>No orders placed yet</li>";
+    } else
+      orderLog.innerHTML = orderHistory
+        .map((order) => `<li>✅ Reordered ${order.name} - ${order.time}</li>`)
+        .join("");
   }
 
   reorderItem(itemName) {
-    const orderLog = document.getElementById("order-log");
-    orderLog.innerHTML =
-      `<li>✅ Reordered ${itemName} - ${new Date().toLocaleTimeString()}</li>` +
-      orderLog.innerHTML;
-    alert(`Reordered ${itemName}!`);
+    this.onReorder(itemName);
   }
 }
 


### PR DESCRIPTION
Reorder the storage item using item names, currently fill the item count to 10
Reordered item will stored in the local storage, the reorder log will show up in the bottom order log

Future improvement:
- layout of the storage item and order log to be side by side instead of top and bottom
- reorder using 'nr' ID instead of storage name 